### PR TITLE
Header parsings fails rfc7230 OWS specification.

### DIFF
--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -207,7 +207,7 @@ void SSDPClass::_send(ssdp_method_t method){
     _modelName, _modelNumber,
     _uuid,
     (method == NONE)?"ST":"NT",
-    _deviceType,
+    _respondType,
    ip[0], ip[1], ip[2], ip[3], _port, _schemaURL
   );
   if(len < 0) return;
@@ -330,6 +330,8 @@ void SSDPClass::_update(){
 #endif
                 break;
               case ST:
+                // save the search term for the reply
+                strlcpy(_respondType, buffer, sizeof(_respondType));
                 if(strcmp(buffer, "ssdp:all")){
                   state = ABORT;
 #ifdef DEBUG_SSDP

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -335,6 +335,7 @@ void SSDPClass::_update(){
             switch(header){
               case START:
               case STRIP:
+              case SKIP:
                 break;
               case MAN:
 #ifdef DEBUG_SSDP

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -347,7 +347,8 @@ void SSDPClass::_update(){
                 }
                 break;
               case MX:
-                _delay = random(0, atoi(buffer)) * 1000L;
+                // delay in ms from 0 to MX*1000 where MX is in seconds
+                _delay = random(0, atoi(buffer) * 1000L);
                 break;
             }
 

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -223,7 +223,7 @@ void SSDPClass::_send(ssdp_method_t method){
     remoteAddr = IPAddress(SSDP_MULTICAST_ADDR);
     remotePort = SSDP_PORT;
 #ifdef DEBUG_SSDP
-    DEBUG_SSDP.println("Sending Notify to ");
+    DEBUG_SSDP.print("Sending Notify to ");
 #endif
   }
 #ifdef DEBUG_SSDP
@@ -280,7 +280,9 @@ void SSDPClass::_update(){
 #ifdef DEBUG_SSDP
         if (message_size) {
             DEBUG_SSDP.println("****************************************************");
-            DEBUG_SSDP.println(_server->remoteIP());
+            DEBUG_SSDP.print(_server->remoteIP());
+            DEBUG_SSDP.print(":");
+            DEBUG_SSDP.println(_server->remotePort());
             DEBUG_SSDP.println(packetBuffer);
             DEBUG_SSDP.println("****************************************************");
         }

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -334,6 +334,7 @@ void SSDPClass::_update(){
           if(cr == 2){
             switch(header){
               case START:
+              case STRIP:
                 break;
               case MAN:
 #ifdef DEBUG_SSDP
@@ -348,7 +349,7 @@ void SSDPClass::_update(){
                 DEBUG_SSDP.printf("ST: '%s'\n",buffer);
 #endif
                 // if looking for all or root reply with upnp:rootdevice
-                if(int _all = strcmp(buffer, "ssdp:all")==0 || strcmp(buffer, "upnp:rootdevice")==0){
+                if(strcmp(buffer, "ssdp:all")==0 || strcmp(buffer, "upnp:rootdevice")==0){
                   _stmatch = true;
                   // set USN suffix
                   strlcpy(_usn_suffix, "::upnp:rootdevice", sizeof(_usn_suffix));

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -326,7 +326,7 @@ void SSDPClass::_update(){
           break;
         case KEY:
           // end of HTTP request parsing. If we find a match start reply delay.
-          if(cr == 4){if (_stmatch) { _pending = true; _process_time = millis(); DEBUG_SSDP.println("END HTTP"); } }
+          if(cr == 4){if (_stmatch) { _pending = true; _process_time = millis(); }}
           else if(c == ':'){ cursor = 0; state = VALUE; }
           else if(c != '\r' && c != '\n' && c != ' ' && cursor < SSDP_BUFFER_SIZE - 1){ buffer[cursor++] = c; buffer[cursor] = '\0'; }
           break;

--- a/ESP32SSDP.h
+++ b/ESP32SSDP.h
@@ -105,6 +105,7 @@ class SSDPClass{
     char _respondType[SSDP_DEVICE_TYPE_SIZE];
 
     bool _pending;
+    bool _stmatch;
     unsigned short _delay;
     unsigned long _process_time;
     unsigned long _notify_time;

--- a/ESP32SSDP.h
+++ b/ESP32SSDP.h
@@ -102,6 +102,7 @@ class SSDPClass{
 
     IPAddress _respondToAddr;
     uint16_t  _respondToPort;
+    char _respondType[SSDP_DEVICE_TYPE_SIZE];
 
     bool _pending;
     unsigned short _delay;

--- a/ESP32SSDP.h
+++ b/ESP32SSDP.h
@@ -111,6 +111,7 @@ class SSDPClass{
 
     char _schemaURL[SSDP_SCHEMA_URL_SIZE];
     char _uuid[SSDP_UUID_SIZE];
+    char _usn_suffix[SSDP_DEVICE_TYPE_SIZE];
     char _deviceType[SSDP_DEVICE_TYPE_SIZE];
     char _friendlyName[SSDP_FRIENDLY_NAME_SIZE];
     char _serialNumber[SSDP_SERIAL_NUMBER_SIZE];


### PR DESCRIPTION
https://greenbytes.de/tech/webdav/rfc7230.html#header.fields
https://greenbytes.de/tech/webdav/rfc7230.html#rule.OWS
SmarThings HUB SSDP sends out its Host header with no white space after ':' causing
the library to fail to parse the message. This patch adds a new state to skip over OWS.