### PR TITLE
Keep original delay on multiple queries, fix bug in NOTIFY not sending correct data.

### DIFF
--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -482,6 +482,9 @@ void SSDPClass::_update(){
 #endif
   if(_notify_time == 0 || (millis() - _notify_time) > (SSDP_INTERVAL * 1000L)){
     _notify_time = millis();
+    // send notify with our root device type
+    strlcpy(_respondType, "upnp:rootdevice", sizeof(_respondType));
+    strlcpy(_usn_suffix, "::upnp:rootdevice", sizeof(_usn_suffix));
 #ifdef DEBUG_SSDP
     DEBUG_SSDP.println("Send Notify");
 #endif

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -303,9 +303,6 @@ void SSDPClass::_update(){
       char c = packetBuffer[process_pos];
      process_pos++;
       (c == '\r' || c == '\n') ? cr++ : cr = 0;
-#ifdef DEBUG_SSDP
-        if ((c == '\r' || c == '\n') && (cr < 2)) DEBUG_SSDP.println(buffer);
-#endif
       switch(state){
         case METHOD:
           if(c == ' '){

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -31,7 +31,7 @@ License (MIT license):
 #include "WiFiUdp.h"
 #include <lwip/ip_addr.h>
 
-//#define DEBUG_SSDP  Serial
+#define DEBUG_SSDP  Serial
 
 #define SSDP_INTERVAL     1200
 #define SSDP_PORT         1900
@@ -416,6 +416,9 @@ void SSDPClass::_update(){
         if (_replySlots[i]->_respondToPort == _respondToPort &&
           _replySlots[i]->_respondToAddr == _respondToAddr
         ) {
+          // keep original delay
+          _delay = _replySlots[i]->_delay;
+          _process_time = _replySlots[i]->_process_time;
 #ifdef DEBUG_SSDP
             DEBUG_SSDP.printf("Remove dupe SSDP reply in slot %i.\n", i);
 #endif

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -31,7 +31,7 @@ License (MIT license):
 #include "WiFiUdp.h"
 #include <lwip/ip_addr.h>
 
-#define DEBUG_SSDP  Serial
+//#define DEBUG_SSDP  Serial
 
 #define SSDP_INTERVAL     1200
 #define SSDP_PORT         1900


### PR DESCRIPTION
Fix reply delay using the first time received if receiving duplicate UDP queries.
Fix NOTIFY not using correct data. Init to correct state before sending.
Remove a verbose test debug section.