### PR TITLE
separated http header & changed device types

### DIFF
--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -117,7 +117,7 @@ SSDPClass::SSDPClass() :
     _usn_suffix[0] = '\0';
     _respondType[0] = '\0';
     _modelNumber[0] = '\0';
-    sprintf(_deviceType, "urn:schemas-upnp-org:device:Basic:1");
+    sprintf(_deviceType, "Basic");
     _friendlyName[0] = '\0';
     _presentationURL[0] = '\0';
     _serialNumber[0] = '\0';
@@ -261,7 +261,7 @@ void SSDPClass::_send(ssdp_method_t method)
     _server->endPacket();
 }
 
-const char * SSDPClass::schema(bool includeheader = true)
+const char * SSDPClass::schema(bool includeheader)
 {
     uint len = strlen(_ssdp_schema_template)
                + 21 //(IP = 15) + 1 (:) + 5 (port)

--- a/ESP32SSDP.cpp
+++ b/ESP32SSDP.cpp
@@ -61,12 +61,14 @@ static const char _ssdp_packet_template[] PROGMEM =
     "LOCATION: http://%u.%u.%u.%u:%u/%s\r\n" // WiFi.localIP(), _port, _schemaURL
     "\r\n";
 
-static const char _ssdp_schema_template[] PROGMEM =
+static const char _ssdp_schema_header[] PROGMEM = 
     "HTTP/1.1 200 OK\r\n"
     "Content-Type: text/xml\r\n"
     "Connection: close\r\n"
     "Access-Control-Allow-Origin: *\r\n"
-    "\r\n"
+    "\r\n";
+
+static const char _ssdp_schema_template[] PROGMEM =
     "<?xml version=\"1.0\"?>"
     "<root xmlns=\"urn:schemas-upnp-org:device-1-0\">"
     "<specVersion>"
@@ -75,7 +77,7 @@ static const char _ssdp_schema_template[] PROGMEM =
     "</specVersion>"
     "<URLBase>http://%u.%u.%u.%u:%u/</URLBase>" // WiFi.localIP(), _port
     "<device>"
-    "<deviceType>%s</deviceType>"
+    "<deviceType>urn:schemas-upnp-org:device:%s:1</deviceType>"
     "<friendlyName>%s</friendlyName>"
     "<presentationURL>%s</presentationURL>"
     "<serialNumber>%s</serialNumber>"
@@ -259,7 +261,7 @@ void SSDPClass::_send(ssdp_method_t method)
     _server->endPacket();
 }
 
-const char * SSDPClass::schema()
+const char * SSDPClass::schema(bool includeheader = true)
 {
     uint len = strlen(_ssdp_schema_template)
                + 21 //(IP = 15) + 1 (:) + 5 (port)
@@ -276,6 +278,9 @@ const char * SSDPClass::schema()
                + SSDP_UUID_SIZE
                + _services.length()
                + _icons.length();
+    if(includeheader)
+       len += strlen(_ssdp_schema_header);
+
     if (_schema) {
         free (_schema);
         _schema = nullptr;
@@ -283,6 +288,8 @@ const char * SSDPClass::schema()
     _schema = (char *)malloc(len+1);
     if (_schema) {
         IPAddress ip = localIP();
+        if(includeheader)
+            sprintf(_schema, _ssdp_schema_header);
         sprintf(_schema, _ssdp_schema_template,
                 ip[0], ip[1], ip[2], ip[3], _port,
                 _deviceType,

--- a/ESP32SSDP.h
+++ b/ESP32SSDP.h
@@ -74,7 +74,7 @@ public:
     void end();
 
     void schema(WiFiClient client);
-    const char * schema(bool includeheader);
+    const char * schema(bool includeheader = true);
 
     void setDeviceType(const String& deviceType)
     {

--- a/ESP32SSDP.h
+++ b/ESP32SSDP.h
@@ -74,7 +74,7 @@ public:
     void end();
 
     void schema(WiFiClient client);
-    const char * schema();
+    const char * schema(bool includeheader);
 
     void setDeviceType(const String& deviceType)
     {

--- a/examples/SSDP/AsyncSSDP.ino
+++ b/examples/SSDP/AsyncSSDP.ino
@@ -1,0 +1,103 @@
+#include "ESPAsyncWebServer.h"
+#include "ESP32SSDP.h"
+
+const char* ssid = "********";
+const char* password = "********";
+
+AsyncWebServer webserver(80);
+
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println();
+    Serial.println("Starting WiFi...");
+
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(ssid, password);
+    if(WiFi.waitForConnectResult() == WL_CONNECTED) {
+
+        Serial.printf("Starting HTTP...\n");
+        webserver.on("/index.html", HTTP_GET, [&](AsyncWebServerRequest *request) {
+            request->send(200, "text/plain", "Hello World!");
+        });
+        webserver.on("/description.xml", HTTP_GET, [&](AsyncWebServerRequest *request) {
+            request->send(200, "text/xml", SSDP.schema(false));
+        });
+        webserver.begin();
+
+        //set schema xml url, nees to match http handler
+        //"ssdp/schema.xml" if not set
+        SSDP.setSchemaURL("description.xml");
+        //set port
+        //80 if not set
+        SSDP.setHTTPPort(80);
+        //set device name
+        //Null string if not set
+        SSDP.setName("Philips hue clone");
+        //set Serial Number
+        //Null string if not set
+        SSDP.setSerialNumber("001788102201");
+        //set device url
+        //Null string if not set
+        SSDP.setURL("index.html");
+        //set model name
+        //Null string if not set
+        SSDP.setModelName("Philips hue bridge 2012");
+        //set model description
+        //Null string if not set
+        SSDP.setModelDescription("This device can be controled by WiFi");
+        //set model number
+        //Null string if not set
+        SSDP.setModelNumber("929000226503");
+        //set model url
+        //Null string if not set
+        SSDP.setModelURL("http://www.meethue.com");
+        //set model manufacturer name
+        //Null string if not set
+        SSDP.setManufacturer("Royal Philips Electronics");
+        //set model manufacturer url
+        //Null string if not set
+        SSDP.setManufacturerURL("http://www.philips.com");
+        //set device type
+        //"urn:schemas-upnp-org:device:Basic:1" if not set
+        SSDP.setDeviceType("rootdevice"); //to appear as root device, other examples: MediaRenderer, MediaServer ...
+        //set server name
+        //"Arduino/1.0" if not set
+        SSDP.setServerName("SSDPServer/1.0");
+        //set UUID, you can use https://www.uuidgenerator.net/
+        //use 38323636-4558-4dda-9188-cda0e6 + 4 last bytes of mac address if not set
+        //use SSDP.setUUID("daa26fa3-d2d4-4072-bc7a-a1b88ab4234a", false); for full UUID
+        SSDP.setUUID("daa26fa3-d2d4-4072-bc7a");
+        //Set icons list, NB: optional, this is ignored under windows
+        SSDP.setIcons(  "<icon>"
+                        "<mimetype>image/png</mimetype>"
+                        "<height>48</height>"
+                        "<width>48</width>"
+                        "<depth>24</depth>"
+                        "<url>icon48.png</url>"
+                        "</icon>");
+        //Set service list, NB: optional for simple device
+        SSDP.setServices(  "<service>"
+                           "<serviceType>urn:schemas-upnp-org:service:SwitchPower:1</serviceType>"
+                           "<serviceId>urn:upnp-org:serviceId:SwitchPower:1</serviceId>"
+                           "<SCPDURL>/SwitchPower1.xml</SCPDURL>"
+                           "<controlURL>/SwitchPower/Control</controlURL>"
+                           "<eventSubURL>/SwitchPower/Event</eventSubURL>"
+                           "</service>");
+
+        Serial.printf("Starting SSDP...\n");
+        SSDP.begin();
+
+        Serial.printf("Ready!\n");
+    } else {
+        Serial.printf("WiFi Failed\n");
+        while(1) {
+            delay(100);
+        }
+    }
+}
+
+void loop()
+{
+    delay(1);
+}

--- a/examples/SSDP/SSDP.ino
+++ b/examples/SSDP/SSDP.ino
@@ -61,7 +61,7 @@ void setup()
         SSDP.setManufacturerURL("http://www.philips.com");
         //set device type
         //"urn:schemas-upnp-org:device:Basic:1" if not set
-        SSDP.setDeviceType("upnp:rootdevice"); //to appear as root device
+        SSDP.setDeviceType("rootdevice"); //to appear as root device, other examples: MediaRenderer, MediaServer ...
         //set server name
         //"Arduino/1.0" if not set
         SSDP.setServerName("SSDPServer/1.0");


### PR DESCRIPTION
Hi, 
I've seen you have included the header directly in the schema().

That's probably not really nice, as it just works with the Arduino included Webserver.

For the Async Webserver (https://github.com/me-no-dev/ESPAsyncWebServer) it's not working out of the box.
Therefore someone wrote a Wrapper of your lib: https://github.com/Lightwell-bg/ssdpAWS

Now it could be used in general and per default, header will be included, so compatible with everything.

Cheers.