### PR TITLE
V2.x compatible to ESP32 core 2.x

### DIFF
--- a/src/ESP32SSDP.cpp
+++ b/src/ESP32SSDP.cpp
@@ -153,6 +153,22 @@ void SSDPClass::end() {
 }
 
 IPAddress SSDPClass::localIP() {
+
+#if (ESP_ARDUINO_VERSION_MAJOR < 3)
+  // Arduino ESP32 2.x board version
+  tcpip_adapter_ip_info_t ip;
+  if (WiFi.getMode() == WIFI_STA) {
+    if (tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_STA, &ip)) {
+      return IPAddress();
+    }
+  } else if (WiFi.getMode() == WIFI_OFF) {
+    if (tcpip_adapter_get_ip_info(TCPIP_ADAPTER_IF_ETH, &ip)) {
+      return IPAddress();
+    }
+  }
+
+#else
+  // Arduino ESP32 3.x board version
   esp_netif_ip_info_t ip;
   if (WiFi.getMode() == WIFI_STA) {
     if (esp_netif_get_ip_info(get_esp_interface_netif(ESP_IF_WIFI_STA), &ip)) {
@@ -163,8 +179,12 @@ IPAddress SSDPClass::localIP() {
       return IPAddress();
     }
   }
+
+#endif 
+
   return IPAddress(ip.ip.addr);
 }
+
 
 void SSDPClass::setUUID(const char *uuid, bool rootonly) {
   // no sanity check is done - TBD


### PR DESCRIPTION
code for 
https://github.com/luc-github/ESP32SSDP/issues/43 

Please consider implementing a library version that is compatible with 3.x and pre-3.x.
using if (ESP_ARDUINO_VERSION_MAJOR < 3)

It is hard for typical Arduino users to distinguish between versions so a version 2.0 that runs with both ESP32 board adoptions is probably welcome.